### PR TITLE
Request is not needed to define policy

### DIFF
--- a/index.html
+++ b/index.html
@@ -253,9 +253,8 @@
       </section>
       <section>
         <h2>Process response policy</h2>
-        <p>Given a [response] (<var>response</var>) and a [request]
-        (<var>request</var>), this algorithm returns a <a>feature
-        policy</a>.</p>
+        <p>Given a [response] (<var>response</var>), this algorithm returns a
+        <a>feature policy</a>.</p>
         <ol>
           <li>Abort these steps if any of the following conditions are true:
             <ol>


### PR DESCRIPTION
The *Process response policy* algorithm specifies a `request` as input, but does not reference it in any way.